### PR TITLE
fix(contract): use `main` keyword for test contract

### DIFF
--- a/contracts/Test.aes
+++ b/contracts/Test.aes
@@ -5,7 +5,7 @@ namespace Lib =
 contract RemoteTest =
     entrypoint test_remote : (int) => int
 
-contract Test =
+main contract Test =
     type number = int
     type string_map = map(string, int)
     type box('a) = 'a


### PR DESCRIPTION
As of the latest HF it is required to prefix the main contract with `main` if there are >= 2 contracts in the same file.