### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,3 +26,4 @@ jobs:
           sudo apt install ./esl-erlang_21.3.8.13-1~debian~stretch_amd64.deb || true
           sudo apt --fix-broken install
     - run: make tests
+    - run: make integration-tests

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ browser-tests: $(BUILDDIR)/js/tests.js
 	@echo Make sure to change the test runner to "tape" in "src/test.js" prior running this command.
 	@echo Open "tests/index.html" in your browser.
 
+integration-tests:
+	./tests/integration/encoder.sh
+	./tests/integration/decoder.sh
+
 coverage: node_modules $(BUILDDIR)/$(JSON_ACIS)
 	npm run coverage
 

--- a/tests/Decoder.js
+++ b/tests/Decoder.js
@@ -64,10 +64,7 @@ test('Decode signature return', t => {
             'cb_nwEBAAABAgMEBQYHCAkKCwwNDg8AAQIDBAUGBwgJCgsMDQ4PAAECAwQFBgcICQoLDA0ODwABAgMEBQYHCAkKCwwNDg/EV2+8',
         ),
         HexStringToByteArray("0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f"),
-        `test_signature(
-            #000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
-            000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
-        )`
+        `test_signature(#000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f)`
     )
 });
 
@@ -152,7 +149,7 @@ test('Decode nested list arguments', t => {
         [5n, 6n]
     ]
 
-    t.deepEqual(decoded, ints, 'test_nested_list([[1,2],[3,4],[5,6]])')
+    t.deepEqual(decoded, ints, 'test_nested_list([[1, 2], [3, 4], [5, 6]])')
 });
 
 test('Decode tuple arguments', t => {
@@ -172,7 +169,7 @@ test('Decode nested tuple arguments', t => {
             [true, false],
             [false, true]
         ],
-        'test_nested_tuple(((true, false), (false true)))'
+        'test_nested_tuple(((true, false), (false, true)))'
     )
 });
 
@@ -334,7 +331,11 @@ test('Decode records map', t => {
             [{x: 1n, y: 2n}, {x: 3n, y: 4n}],
             [{x: 100n, y: 12n}, {x: 23n, y: 99n}],
         ]),
-        'test_records_map([[{x: 0, y: 0}, {x: 1, y: 1}], [{x: 1, y: 2}, {x: 3, y: 4}], [{x: 100, y: 12}, {x: 23, y: 99}]])'
+        `test_records_map(
+                {[{x = 0, y = 0}] = {x = 1, y = 1},
+                [{x = 1, y = 2}] = {x = 3, y = 4},
+                [{x = 100, y = 12}] = {x = 23, y = 99}}
+        )`
     )
 });
 

--- a/tests/Encoder.js
+++ b/tests/Encoder.js
@@ -48,7 +48,7 @@ test('Encode bytes arguments', t => {
 test('Encode string arguments', t => {
     t.plan(1)
     const encoded = encoder.encode(CONTRACT, 'test_string', ["whoolymoly"])
-    t.is(encoded, 'cb_KxHwzCuVGyl3aG9vbHltb2x5zwMSnw==', 'test_bytes("whoolymoly")')
+    t.is(encoded, 'cb_KxHwzCuVGyl3aG9vbHltb2x5zwMSnw==', 'test_string("whoolymoly")')
 });
 
 test('Encode hash arguments', t => {
@@ -144,7 +144,7 @@ test('Encode bits arguments', t => {
     t.is(encoded2, 'cb_KxG27kGGG88BYlyOgw==', 'test_bits(Bits.all)')
 
     const encoded3 = encoder.encode(CONTRACT, 'test_bits', [[1]])
-    t.is(encoded3, 'cb_KxG27kGGG08BD4ordQ==', 'test_bits(Bits.set(Bits.none, 0)')
+    t.is(encoded3, 'cb_KxG27kGGG08BD4ordQ==', 'test_bits(Bits.set(Bits.none, 0))')
 });
 
 test('Encode list arguments', t => {
@@ -188,7 +188,7 @@ test('Encode tuple arguments', t => {
 test('Encode nested tuple arguments', t => {
     t.plan(1)
     const encoded = encoder.encode(CONTRACT, 'test_nested_tuple', [[[true, false], [false, true]]])
-    t.is(encoded, 'cb_KxHkKCkeGysr/38rf/+ZQRDt', 'test_nested_tuple(((true, false), (false true)))')
+    t.is(encoded, 'cb_KxHkKCkeGysr/38rf/+ZQRDt', 'test_nested_tuple(((true, false), (false, true)))')
 });
 
 test('Encode simple variant arguments', t => {

--- a/tests/integration/decoder.sh
+++ b/tests/integration/decoder.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+CONTRACT="contracts/Test.aes"
+COMPILER="./bin/aesophia_cli"
+TESTS_PATH="tests/Decoder.js"
+
+function decode() {
+    ${COMPILER:-} ${CONTRACT:-} --call_result_fun "$1" --call_result "$2" | tail -n+2
+}
+
+function test_decoder() {
+    echo -n "$1 ("$2") -> "
+    DECODED=$(decode "$1" "$2")
+    echo "$DECODED"
+    grep -FA 2 "$1" ${TESTS_PATH:-} | grep -qF "$DECODED"
+}
+
+test_decoder 'test_bool' 'cb_/8CwV/U='
+test_decoder 'test_single_int' 'cb_b4MC7W/bKkpn'
+test_decoder 'test_bytes' 'cb_nwEJvu+rlRrs'
+test_decoder 'test_string' 'cb_KXdob29seW1vbHlGazSE'
+test_decoder 'test_hash' 'cb_nwGBAAECAwQFBgcICQoLDA0ODwABAgMEBQYHCAkKCwwNDg/55Yfk'
+test_decoder 'test_signature' 'cb_nwEBAAABAgMEBQYHCAkKCwwNDg8AAQIDBAUGBwgJCgsMDQ4PAAECAwQFBgcICQoLDA0ODwABAgMEBQYHCAkKCwwNDg/EV2+8'
+test_decoder 'test_account_address' 'cb_nwCg3mi/4bID5R9SNRugh/ebeCjmoUDwwxSmcMcAOz/1cHVYbXWK'
+test_decoder 'test_contract_address' 'cb_nwKgH8DQmexaE8uTKKMX/OzYUrH3SJ5eALoJVzw8LbaYVVPlirXw'
+test_decoder 'test_oracle_address' 'cb_nwOgyvIqJE7awD0m8CoX2SOULQVc/IYjKLJaUcKEvJ1CDkkkbvWd'
+test_decoder 'test_oracle_query_address' 'cb_nwSg7R7n3AJ40FzpUJRzxQqT1Dooso1QMvbffapEL+E3E0g6bqyq'
+test_decoder 'test_bits' 'cb_TwBixWzt'
+test_decoder 'test_bits' 'cb_zwH34yVW'
+test_decoder 'test_bits' 'cb_TwEPbJQb'
+test_decoder 'test_list' 'cb_cwIEBgoQGiqNmBRX'
+test_decoder 'test_nested_list' 'cb_MyMCBCMGCCMKDPLAUC0='
+test_decoder 'test_tuple' 'cb_K/9/fDzeoA=='
+test_decoder 'test_nested_tuple' 'cb_Kyv/fyt//701yEI='
+test_decoder 'test_simple_map' 'cb_LwEOfzGit9U='
+test_decoder 'test_nested_map' 'cb_LwMALwEAfwIvAQL/BC8BEP8Q+3ou'
+test_decoder 'test_variants' 'cb_r4QAAAEAAT8xtJ9f'
+test_decoder 'test_variants' 'cb_r4QAAAEAAhsOfGqVXg=='
+test_decoder 'test_template_variants' 'cb_r4IABAFLDv8SKhktM40='
+test_decoder 'test_int_type' 'cb_DtbN98k='
+test_decoder 'test_map_type' 'cb_LwENZm9vJjJRlLM='
+test_decoder 'test_template_type' 'cb_DtbN98k='
+test_decoder 'test_optional' 'cb_r4IAAQA/aHG2bw=='
+test_decoder 'test_optional' 'cb_r4IAAQEbb4IBVPA+5jI='
+test_decoder 'test_record' 'cb_KwAAUjeM0Q=='
+test_decoder 'test_nested_record' 'cb_OysCBAYISeTR0A=='
+test_decoder 'test_records_list' 'cb_MysAACsCAisEBMjzXEk='
+test_decoder 'test_records_map' 'cb_LwMrAAArAgIrAgQrBggrbyQYKy5vIzf5arA='
+test_decoder 'test_primitives_tuple' 'cb_ewL/EXRlc3RPAJ8BCb7vnwGBAAECAwQFBgcICQoLDA0ODwABAgMEBQYHCAkKCwwNDg+fAQEAAAECAwQFBgcICQoLDA0ODwABAgMEBQYHCAkKCwwNDg8AAQIDBAUGBwgJCgsMDQ4PAAECAwQFBgcICQoLDA0ODzwY0fk='
+test_decoder 'test_addresses_tuple' 'cb_S58AoN5ov+GyA+UfUjUboIf3m3go5qFA8MMUpnDHADs/9XB1nwKgH8DQmexaE8uTKKMX/OzYUrH3SJ5eALoJVzw8LbaYVVOfA6DK8iokTtrAPSbwKhfZI5QtBVz8hiMoslpRwoS8nUIOSZ8EoO0e59wCeNBc6VCUc8UKk9Q6KLKNUDL2332qRC/hNxNI/pLnKw=='
+test_decoder 'test_complex_tuple' 'cb_WysCAq+EAAABAAIbBjMCBAYvAgIEBggrCgyRsE4R'

--- a/tests/integration/encoder.sh
+++ b/tests/integration/encoder.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+CONTRACT="contracts/Test.aes"
+COMPILER="./bin/aesophia_cli"
+TESTS_PATH="tests/Encoder.js"
+
+function encode() {
+    ${COMPILER:-} --create_calldata ${CONTRACT:-} --call "$1" | tail -n+2
+}
+
+function test_encoder() {
+    echo -n "$1 -> "
+    ENCODED=$(encode "$1")
+    echo "$ENCODED"
+    grep -qF $ENCODED ${TESTS_PATH:-}
+}
+
+test_encoder 'init()'
+test_encoder 'test_empty()'
+test_encoder 'test_bool(true, false)'
+test_encoder 'test_single_int(63)'
+test_encoder 'test_single_int(-63)'
+test_encoder 'test_int(63, -63, 64, -64)'
+test_encoder 'test_bytes(#beef)'
+test_encoder 'test_string("whoolymoly")'
+test_encoder 'test_hash(#000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f)'
+test_encoder 'test_signature(#000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f)'
+test_encoder 'test_account_address(ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt)'
+test_encoder 'test_contract_address(ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ)'
+test_encoder 'test_oracle_address(ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5)'
+test_encoder 'test_oracle_query_address(oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY)'
+test_encoder 'test_bits(Bits.none)'
+test_encoder 'test_bits(Bits.all)'
+test_encoder 'test_bits(Bits.set(Bits.none, 0))'
+test_encoder 'test_list([1, 2, 3, 5, 8, 13, 21])'
+test_encoder 'test_nested_list([[1,2],[3,4],[5,6]])'
+test_encoder 'test_simple_map({[7] = false})'
+test_encoder 'test_nested_map({[0] = {[0] = false}, [1] = {[1] = true}, [2] = {[8] = true}})'
+test_encoder 'test_tuple((true, false))'
+test_encoder 'test_nested_tuple(((true, false), (false, true)))'
+test_encoder 'test_variants(No)'
+test_encoder 'test_variants(Yep(7))'
+test_encoder 'test_template_variants(Any(7, true, 9, 21))'
+test_encoder 'test_int_type(7)'
+test_encoder 'test_map_type({["foo"] = 19})'
+test_encoder 'test_template_type(7)'
+test_encoder 'test_template_maze(Any({origin = {x = 1, y = 2}, a = 3, b = 4}, Yep(10), 20, {origin = {x = 1, y = 2}, a = 3, b = 4}))'
+test_encoder 'test_record({x = 0, y = 0})'
+test_encoder 'test_nested_record({origin = {x = 1, y = 2}, a = 3, b = 4})'
+test_encoder 'test_lib_type(404)'
+test_encoder 'test_optional(None)'
+test_encoder 'test_optional(Some(404))'
+test_encoder 'test_ttl(RelativeTTL(50))'
+test_encoder 'test_ttl(FixedTTL(50))'


### PR DESCRIPTION
Integration tests compare the JS implementation with the [reference CLI compiler](https://github.com/aeternity/aesophia_cli).
While current implementation is not 100% reliable it is pretty simple and decoupled.

Better implementation would be creating a JS CLI version of the en/decoder and compare with the reference, however that CLI must be able to parse input and output in the same format as the reference compiler, which is out of scope of this project.