### PR TITLE
Strict boolean validation in FateBool

### DIFF
--- a/src/types/FateBool.js
+++ b/src/types/FateBool.js
@@ -5,7 +5,10 @@ class FateBool extends FateData {
   constructor(value) {
     super('bool')
 
-    this._value = !!value
+    if (typeof value !== 'boolean') {
+      throw new Error(`"${value}" must be a boolean`)
+    }
+    this._value = value
   }
 
   get value() {

--- a/tests/Serializers/BoolSerializer.js
+++ b/tests/Serializers/BoolSerializer.js
@@ -10,12 +10,12 @@ test('Serialize', t => {
     t.deepEqual(s.serialize(false), [127])
 
     t.deepEqual(s.serialize(new FateBool(true)), [255])
-    t.deepEqual(s.serialize(new FateBool(1)), [255])
-    t.deepEqual(s.serialize(new FateBool("qwe")), [255])
+    t.throws(() => s.serialize(new FateBool(1)), { message: '"1" must be a boolean' })
+    t.throws(() => s.serialize(new FateBool("qwe")), { message: '"qwe" must be a boolean' })
 
     t.deepEqual(s.serialize(new FateBool(false)), [127])
-    t.deepEqual(s.serialize(new FateBool(0)), [127])
-    t.deepEqual(s.serialize(new FateBool("")), [127])
+    t.throws(() => s.serialize(new FateBool(0)), { message: '"0" must be a boolean' })
+    t.throws(() => s.serialize(new FateBool("")), { message: '"" must be a boolean' })
 });
 
 test('Deserialize', t => {


### PR DESCRIPTION
In SDK we had a strict validation of input arguments, is it ok to the same on calldata side? I would like to add same validation for other types.