### PR TITLE
Validate string in HexStringToByteArray

### DIFF
--- a/src/utils/HexStringToByteArray.js
+++ b/src/utils/HexStringToByteArray.js
@@ -1,18 +1,13 @@
 // TODO consider using Buffer.from(<string>, 'hex') instead
 const HexStringToByteArray = function (str) {
-    const start = str.startsWith('0x') ? 2 : 0
-    let ints = []
-
-    for (let i = start, charsLength = str.length; i < charsLength; i += 2) {
-        const [int1, int2] = [0, 1].map(j => parseInt(str[i + j], 16))
-        const isOddEnd = i + 1 >= charsLength
-        if (Number.isNaN(int1) || Number.isNaN(int2) && !isOddEnd) {
-            throw new Error(`Invalid hex string: ${str}`)
-        }
-        ints.push(isOddEnd ? int1 : (int1 << 4) + int2)
+    const match = str.match(new RegExp(/^(0x)?([a-f0-9]*)$/, 'i'))
+    if (!match) {
+        throw new Error(`Invalid hex string: ${str}`)
     }
-
-    return new Uint8Array(ints)
+    return new Uint8Array(match[2]
+        .split(/(.{1,2})/)
+        .filter(el => el)
+        .map(el => parseInt(el, 16)))
 }
 
 module.exports = HexStringToByteArray

--- a/src/utils/HexStringToByteArray.js
+++ b/src/utils/HexStringToByteArray.js
@@ -1,10 +1,15 @@
+// TODO consider using Buffer.from(<string>, 'hex') instead
 const HexStringToByteArray = function (str) {
     const start = str.startsWith('0x') ? 2 : 0
-    let ints = [];
+    let ints = []
 
     for (let i = start, charsLength = str.length; i < charsLength; i += 2) {
-        const hex = str.substring(i, i + 2)
-        ints.push(parseInt(hex, 16));
+        const [int1, int2] = [0, 1].map(j => parseInt(str[i + j], 16))
+        const isOddEnd = i + 1 >= charsLength
+        if (Number.isNaN(int1) || Number.isNaN(int2) && !isOddEnd) {
+            throw new Error(`Invalid hex string: ${str}`)
+        }
+        ints.push(isOddEnd ? int1 : (int1 << 4) + int2)
     }
 
     return new Uint8Array(ints)

--- a/tests/utils/HexStringToByteArray.js
+++ b/tests/utils/HexStringToByteArray.js
@@ -1,0 +1,15 @@
+const test = require('../test.js')
+const HexStringToByteArray = require('../../src/utils/HexStringToByteArray.js')
+
+const b = (value) => new Uint8Array(value)
+
+test('HexStringToByteArray', t => {
+    t.plan(7)
+    t.deepEqual(HexStringToByteArray(''), b([]))
+    t.deepEqual(HexStringToByteArray('0x'), b([]))
+    t.deepEqual(HexStringToByteArray('1'), b([1]))
+    t.deepEqual(HexStringToByteArray('01'), b([1]))
+    t.deepEqual(HexStringToByteArray('0x01'), b([1]))
+    t.deepEqual(HexStringToByteArray('c0ffee'), b([192, 255, 238]))
+    t.throws(() => HexStringToByteArray('coffee'), { message: 'Invalid hex string: coffee' })
+})


### PR DESCRIPTION
Fixes replacing non-hex chars with zeros (`new Uint8Array([parseInt('Z', 16)])` => `new Uint8Array([NaN])` => `Uint8Array(1) [ 0 ]`). Also, can be used a RegExp instead, but 🤷‍♀️ 