### PR TITLE
Accept only ae-encoded addresses, check its length

### DIFF
--- a/src/DataFactory.js
+++ b/src/DataFactory.js
@@ -76,11 +76,11 @@ class DataFactory {
         }
 
         if (type.name === 'oracle_address') {
-            return new FateOracleAddress(value, type.valueTypes)
+            return new FateOracleAddress(value)
         }
 
         if (type.name === 'oracle_query_address') {
-            return new FateOracleQueryAddress(value, type.valueTypes)
+            return new FateOracleQueryAddress(value)
         }
 
         if (type.name === 'list') {

--- a/src/Serializers/AddressSerializer.js
+++ b/src/Serializers/AddressSerializer.js
@@ -1,6 +1,6 @@
 const RLP = require('rlp')
 const FateTag = require('../FateTag')
-const FateAccountAddress = require('../types/FateAccountAddress')
+const FateAccountAddressRaw = require('../types/FateAccountAddressRaw')
 
 class AddressSerializer {
     serialize(data) {
@@ -22,7 +22,7 @@ class AddressSerializer {
         const decoded = RLP.decode(buffer.slice(2), true)
 
         return [
-            new FateAccountAddress(decoded.data),
+            new FateAccountAddressRaw(decoded.data),
             new Uint8Array(decoded.remainder)
         ]
     }

--- a/src/Serializers/ChannelSerializer.js
+++ b/src/Serializers/ChannelSerializer.js
@@ -1,6 +1,6 @@
 const RLP = require('rlp')
 const FateTag = require('../FateTag')
-const FateChannelAddress = require('../types/FateChannelAddress')
+const FateChannelAddressRaw = require('../types/FateChannelAddressRaw')
 
 class ChannelSerializer {
     serialize(data) {
@@ -22,7 +22,7 @@ class ChannelSerializer {
         const decoded = RLP.decode(buffer.slice(2), true)
 
         return [
-            new FateChannelAddress(decoded.data),
+            new FateChannelAddressRaw(decoded.data),
             new Uint8Array(decoded.remainder)
         ]
     }

--- a/src/Serializers/ContractSerializer.js
+++ b/src/Serializers/ContractSerializer.js
@@ -1,6 +1,6 @@
 const RLP = require('rlp')
 const FateTag = require('../FateTag')
-const FateContractAddress = require('../types/FateContractAddress')
+const FateContractAddressRaw = require('../types/FateContractAddressRaw')
 
 class ContractSerializer {
     serialize(data) {
@@ -22,7 +22,7 @@ class ContractSerializer {
         const decoded = RLP.decode(buffer.slice(2), true)
 
         return [
-            new FateContractAddress(decoded.data),
+            new FateContractAddressRaw(decoded.data),
             new Uint8Array(decoded.remainder)
         ]
     }

--- a/src/Serializers/OracleQuerySerializer.js
+++ b/src/Serializers/OracleQuerySerializer.js
@@ -1,6 +1,6 @@
 const RLP = require('rlp')
 const FateTag = require('../FateTag')
-const FateOracleQueryAddress = require('../types/FateOracleQueryAddress')
+const FateOracleQueryAddressRaw = require('../types/FateOracleQueryAddressRaw')
 
 class OracleQuerySerializer {
     serialize(data) {
@@ -22,7 +22,7 @@ class OracleQuerySerializer {
         const decoded = RLP.decode(buffer.slice(2), true)
 
         return [
-            new FateOracleQueryAddress(decoded.data),
+            new FateOracleQueryAddressRaw(decoded.data),
             new Uint8Array(decoded.remainder)
         ]
     }

--- a/src/Serializers/OracleSerializer.js
+++ b/src/Serializers/OracleSerializer.js
@@ -1,6 +1,6 @@
 const RLP = require('rlp')
 const FateTag = require('../FateTag')
-const FateOracleAddress = require('../types/FateOracleAddress')
+const FateOracleAddressRaw = require('../types/FateOracleAddressRaw')
 
 class OracleSerializer {
     serialize(data) {
@@ -22,7 +22,7 @@ class OracleSerializer {
         const decoded = RLP.decode(buffer.slice(2), true)
 
         return [
-            new FateOracleAddress(decoded.data),
+            new FateOracleAddressRaw(decoded.data),
             new Uint8Array(decoded.remainder)
         ]
     }

--- a/src/types/FateAccountAddress.js
+++ b/src/types/FateAccountAddress.js
@@ -2,7 +2,7 @@ const FateAddress = require('./FateAddress')
 
 class FateAccountAddress extends FateAddress {
     constructor(value) {
-        super(value, 32, 'account_address', 'ak')
+        super(value, 'account_address', 'ak')
     }
 }
 

--- a/src/types/FateAccountAddressRaw.js
+++ b/src/types/FateAccountAddressRaw.js
@@ -1,0 +1,9 @@
+const FateAddressRaw = require('./FateAddressRaw')
+
+class FateAccountAddressRaw extends FateAddressRaw {
+    constructor(value) {
+        super(value, 'account_address', 'ak')
+    }
+}
+
+module.exports = FateAccountAddressRaw

--- a/src/types/FateAddress.js
+++ b/src/types/FateAddress.js
@@ -14,10 +14,10 @@ const base58Decode = (prefix, value) => {
 }
 
 class FateAddress extends FateBytes {
-    constructor(value, size, name, prefix) {
-    // eventually decode the value
+    constructor(value, name, prefix) {
+        // eventually decode the value
         const decoded = base58Decode(prefix, value)
-        super(decoded, size, name)
+        super(decoded, 32, name)
 
         this._prefix = prefix
     }

--- a/src/types/FateAddress.js
+++ b/src/types/FateAddress.js
@@ -1,37 +1,15 @@
-const FateBytes = require('./FateBytes')
+const FateAddressRaw = require('./FateAddressRaw')
 const bs58check = require('bs58check')
 
-const base58Decode = (prefix, value) => {
-    if (typeof value === 'string' && value.charAt(2) === '_') {
-        if (!value.startsWith(prefix)) {
-            throw new Error('Invalid prefix: ' + value.substring(0, 2))
-        }
-
-        return bs58check.decode(value.substring(prefix.length + 1))
-    }
-
-    return value
-}
-
-class FateAddress extends FateBytes {
+class FateAddress extends FateAddressRaw {
     constructor(value, name, prefix) {
-        // eventually decode the value
-        const decoded = base58Decode(prefix, value)
-        super(decoded, 32, name)
+        const asString = value.toString()
+        if (!asString.startsWith(prefix + '_')) {
+            throw new Error(`Address should start with ${prefix}_, got ${asString} instead`)
+        }
+        const asBytes = bs58check.decode(asString.substring(prefix.length + 1))
 
-        this._prefix = prefix
-    }
-
-    get prefix() {
-        return this._prefix
-    }
-
-    valueOf() {
-        return this.base58Encode()
-    }
-
-    base58Encode() {
-        return this.prefix + '_' + bs58check.encode(this.value)
+        super(asBytes, name, prefix)
     }
 }
 

--- a/src/types/FateAddressRaw.js
+++ b/src/types/FateAddressRaw.js
@@ -1,0 +1,24 @@
+const FateBytes = require('./FateBytes')
+const bs58check = require('bs58check')
+
+class FateAddressRaw extends FateBytes {
+    constructor(value, name, prefix) {
+        super(value, 32, name)
+
+        this._prefix = prefix
+    }
+
+    get prefix() {
+        return this._prefix
+    }
+
+    valueOf() {
+        return this.base58Encode()
+    }
+
+    base58Encode() {
+        return this.prefix + '_' + bs58check.encode(this.value)
+    }
+}
+
+module.exports = FateAddressRaw

--- a/src/types/FateBytes.js
+++ b/src/types/FateBytes.js
@@ -21,7 +21,9 @@ class FateBytes extends FateData {
 
         this._value = toByteArray(value)
 
-        // not implemented yet
+        if (size && this._value.byteLength !== size) {
+            throw new Error(`Invalid length: got ${this._value.byteLength} bytes instead of ${size} bytes`)
+        }
         this._size = size
     }
 

--- a/src/types/FateChannelAddress.js
+++ b/src/types/FateChannelAddress.js
@@ -2,7 +2,7 @@ const FateAddress = require('./FateAddress')
 
 class FateChannelAddress extends FateAddress {
     constructor(value) {
-        super(value, 32, 'channel_address', 'ch')
+        super(value, 'channel_address', 'ch')
     }
 }
 

--- a/src/types/FateChannelAddressRaw.js
+++ b/src/types/FateChannelAddressRaw.js
@@ -1,0 +1,9 @@
+const FateAddressRaw = require('./FateAddressRaw')
+
+class FateChannelAddressRaw extends FateAddressRaw {
+    constructor(value) {
+        super(value, 'channel_address', 'ch')
+    }
+}
+
+module.exports = FateChannelAddressRaw

--- a/src/types/FateContractAddress.js
+++ b/src/types/FateContractAddress.js
@@ -2,7 +2,7 @@ const FateAddress = require('./FateAddress')
 
 class FateContractAddress extends FateAddress {
     constructor(value) {
-        super(value, 32, 'contract_address', 'ct')
+        super(value, 'contract_address', 'ct')
     }
 }
 

--- a/src/types/FateContractAddressRaw.js
+++ b/src/types/FateContractAddressRaw.js
@@ -1,0 +1,9 @@
+const FateAddressRaw = require('./FateAddressRaw')
+
+class FateContractAddressRaw extends FateAddressRaw {
+    constructor(value) {
+        super(value, 'contract_address', 'ct')
+    }
+}
+
+module.exports = FateContractAddressRaw

--- a/src/types/FateOracleAddress.js
+++ b/src/types/FateOracleAddress.js
@@ -2,7 +2,7 @@ const FateAddress = require('./FateAddress')
 
 class FateOracleAddress extends FateAddress {
     constructor(value) {
-        super(value, 32, 'oracle_address', 'ok')
+        super(value, 'oracle_address', 'ok')
     }
 }
 

--- a/src/types/FateOracleAddressRaw.js
+++ b/src/types/FateOracleAddressRaw.js
@@ -1,0 +1,9 @@
+const FateAddressRaw = require('./FateAddressRaw')
+
+class FateOracleAddressRaw extends FateAddressRaw {
+    constructor(value) {
+        super(value, 'oracle_address', 'ok')
+    }
+}
+
+module.exports = FateOracleAddressRaw

--- a/src/types/FateOracleQueryAddress.js
+++ b/src/types/FateOracleQueryAddress.js
@@ -2,7 +2,7 @@ const FateAddress = require('./FateAddress')
 
 class FateOracleQueryAddress extends FateAddress {
     constructor(value) {
-        super(value, 32, 'oracle_query_address', 'oq')
+        super(value, 'oracle_query_address', 'oq')
     }
 }
 

--- a/src/types/FateOracleQueryAddressRaw.js
+++ b/src/types/FateOracleQueryAddressRaw.js
@@ -1,0 +1,9 @@
+const FateAddressRaw = require('./FateAddressRaw')
+
+class FateOracleQueryAddressRaw extends FateAddressRaw {
+    constructor(value) {
+        super(value, 'oracle_query_address', 'oq')
+    }
+}
+
+module.exports = FateOracleQueryAddressRaw

--- a/tests/Encoder.js
+++ b/tests/Encoder.js
@@ -87,35 +87,20 @@ test('Encode account address arguments', t => {
         encoder.encode(
             CONTRACT,
             'test_account_address',
-            ["0xDE68BFE1B203E51F52351BA087F79B7828E6A140F0C314A670C7003B3FF57075"]
-        ),
-        'cb_KxHgYyOEG58AoN5ov+GyA+UfUjUboIf3m3go5qFA8MMUpnDHADs/9XB1FYw7tQ==',
-        'test_account_address(ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt)'
-    )
-
-    t.is(
-        encoder.encode(
-            CONTRACT,
-            'test_account_address',
             ["ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt"]
         ),
         'cb_KxHgYyOEG58AoN5ov+GyA+UfUjUboIf3m3go5qFA8MMUpnDHADs/9XB1FYw7tQ==',
         'test_account_address(ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt)'
     )
+
+    t.throws(
+        () => encoder.encode(CONTRACT, 'test_account_address', ['test-string']),
+        { message: 'Address should start with ak_, got test-string instead' }
+    )
 })
 
 test('Encode contract address arguments', t => {
-    t.plan(2)
-    t.is(
-        encoder.encode(
-            CONTRACT,
-            'test_contract_address',
-            ["0x1FC0D099EC5A13CB9328A317FCECD852B1F7489E5E00BA09573C3C2DB6985553"]
-        ),
-        'cb_KxELEfrsG58CoB/A0JnsWhPLkyijF/zs2FKx90ieXgC6CVc8PC22mFVTzM0KJQ==',
-        'test_contract_address(ct_Ez6MyeTMm17YnTnDdHTSrzMEBKmy7Uz2sXu347bTDPgVH2ifJ)'
-    )
-
+    t.plan(1)
     t.is(
         encoder.encode(
             CONTRACT,
@@ -128,17 +113,7 @@ test('Encode contract address arguments', t => {
 })
 
 test('Encode oracle address arguments', t => {
-    t.plan(2)
-    t.is(
-        encoder.encode(
-            CONTRACT,
-            'test_oracle_address',
-            ["0xCAF22A244EDAC03D26F02A17D923942D055CFC862328B25A51C284BC9D420E49"]
-        ),
-        'cb_KxGPms0RG58DoMryKiRO2sA9JvAqF9kjlC0FXPyGIyiyWlHChLydQg5Jyfi1MA==',
-        'test_oracle_address(ok_2YNyxd6TRJPNrTcEDCe9ra59SVUdp9FR9qWC5msKZWYD9bP9z5)'
-    )
-
+    t.plan(1)
     t.is(
         encoder.encode(
             CONTRACT,
@@ -151,17 +126,7 @@ test('Encode oracle address arguments', t => {
 })
 
 test('Encode oracle query address arguments', t => {
-    t.plan(2)
-    t.is(
-        encoder.encode(
-            CONTRACT,
-            'test_oracle_query_address',
-            ["0xED1EE7DC0278D05CE9509473C50A93D43A28B28D5032F6DF7DAA442FE1371348"]
-        ),
-        'cb_KxFBufYfG58EoO0e59wCeNBc6VCUc8UKk9Q6KLKNUDL2332qRC/hNxNIgI8x6g==',
-        'test_oracle_query_address(oq_2oRvyowJuJnEkxy58Ckkw77XfWJrmRgmGaLzhdqb67SKEL1gPY)'
-    )
-
+    t.plan(1)
     t.is(
         encoder.encode(
             CONTRACT,

--- a/tests/Serializer.js
+++ b/tests/Serializer.js
@@ -9,11 +9,11 @@ const FateList = require('../src/types/FateList')
 const FateMap = require('../src/types/FateMap')
 const FateVariant = require('../src/types/FateVariant')
 const FateBytes = require('../src/types/FateBytes')
-const FateAccountAddress = require('../src/types/FateAccountAddress')
-const FateContractAddress = require('../src/types/FateContractAddress')
-const FateOracleAddress = require('../src/types/FateOracleAddress')
-const FateOracleQueryAddress = require('../src/types/FateOracleQueryAddress')
-const FateChannelAddress = require('../src/types/FateChannelAddress')
+const FateAccountAddressRaw = require('../src/types/FateAccountAddressRaw')
+const FateContractAddressRaw = require('../src/types/FateContractAddressRaw')
+const FateOracleAddressRaw = require('../src/types/FateOracleAddressRaw')
+const FateOracleQueryAddressRaw = require('../src/types/FateOracleQueryAddressRaw')
+const FateChannelAddressRaw = require('../src/types/FateChannelAddressRaw')
 const {FateTypeInt, FateTypeBool} = require('../src/FateTypes')
 
 const serializer = new Serializer()
@@ -48,23 +48,28 @@ test('Serialize all types', t => {
         [159,1,9,190,239]
     )
     t.deepEqual(
-        ser(t, new FateAccountAddress("0xfedcba9876543210")),
-        [159,0,136,254,220,186,152,118,84,50,16]
+        ser(t, new FateAccountAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,0,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
     t.deepEqual(
-        ser(t, new FateContractAddress("0xfedcba9876543210")),
-        [159,2,136,254,220,186,152,118,84,50,16]
+        ser(t, new FateContractAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,2,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
     t.deepEqual(
-        ser(t, new FateOracleAddress("0xfedcba9876543210")),
-        [159,3,136,254,220,186,152,118,84,50,16]
+        ser(t, new FateOracleAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,3,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
     t.deepEqual(
-        ser(t, new FateOracleQueryAddress("0xfedcba9876543210")),
-        [159,4,136,254,220,186,152,118,84,50,16]
+        ser(t, new FateOracleQueryAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,4,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
     t.deepEqual(
-        ser(t, new FateChannelAddress("0xfedcba9876543210")),
-        [159,5,136,254,220,186,152,118,84,50,16]
+        ser(t, new FateChannelAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,5,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
 })

--- a/tests/Serializers/AddressSerializer.js
+++ b/tests/Serializers/AddressSerializer.js
@@ -1,14 +1,16 @@
 const test = require('../test')
 const AddressSerializer = require('../../src/Serializers/AddressSerializer')
 const FateAccountAddress = require('../../src/types/FateAccountAddress')
+const FateAccountAddressRaw = require('../../src/types/FateAccountAddressRaw')
 
 const s = new AddressSerializer()
 
 test('Serialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.serialize(new FateAccountAddress("0xfedcba9876543210")),
-        [159,0,136,254,220,186,152,118,84,50,16]
+        s.serialize(new FateAccountAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,0,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
 
     t.deepEqual(
@@ -21,8 +23,9 @@ test('Serialize', t => {
 test('Deserialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.deserialize([159,0,136,254,220,186,152,118,84,50,16]),
-        new FateAccountAddress("0xfedcba9876543210")
+        s.deserialize([159,0,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,
+            186,152,118,84,50,16,254,220,186,152,118,84,50,16]),
+        new FateAccountAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")
     )
 
     t.is(

--- a/tests/Serializers/ChannelSerializer.js
+++ b/tests/Serializers/ChannelSerializer.js
@@ -1,14 +1,16 @@
 const test = require('../test')
 const ChannelSerializer = require('../../src/Serializers/ChannelSerializer')
 const FateChannelAddress = require('../../src/types/FateChannelAddress')
+const FateChannelAddressRaw = require('../../src/types/FateChannelAddressRaw')
 
 const s = new ChannelSerializer()
 
 test('Serialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.serialize(new FateChannelAddress("0xfedcba9876543210")),
-        [159,5,136,254,220,186,152,118,84,50,16]
+        s.serialize(new FateChannelAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,5,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
 
     t.deepEqual(
@@ -21,8 +23,9 @@ test('Serialize', t => {
 test('Deserialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.deserialize([159,5,136,254,220,186,152,118,84,50,16]),
-        new FateChannelAddress("0xfedcba9876543210")
+        s.deserialize([159,5,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,
+            186,152,118,84,50,16,254,220,186,152,118,84,50,16]),
+        new FateChannelAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")
     )
 
     t.is(

--- a/tests/Serializers/ContractSerializer.js
+++ b/tests/Serializers/ContractSerializer.js
@@ -1,14 +1,16 @@
 const test = require('../test')
 const ContractSerializer = require('../../src/Serializers/ContractSerializer')
 const FateContractAddress = require('../../src/types/FateContractAddress')
+const FateContractAddressRaw = require('../../src/types/FateContractAddressRaw')
 
 const s = new ContractSerializer()
 
 test('Serialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.serialize(new FateContractAddress("0xfedcba9876543210")),
-        [159,2,136,254,220,186,152,118,84,50,16]
+        s.serialize(new FateContractAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,2,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
 
     t.deepEqual(
@@ -21,8 +23,9 @@ test('Serialize', t => {
 test('Deserialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.deserialize([159,2,136,254,220,186,152,118,84,50,16]),
-        new FateContractAddress("0xfedcba9876543210")
+        s.deserialize([159,2,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,
+            186,152,118,84,50,16,254,220,186,152,118,84,50,16]),
+        new FateContractAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")
     )
 
     t.is(

--- a/tests/Serializers/OracleQuerySerializer.js
+++ b/tests/Serializers/OracleQuerySerializer.js
@@ -1,14 +1,16 @@
 const test = require('../test')
 const OracleQuerySerializer = require('../../src/Serializers/OracleQuerySerializer')
 const FateOracleQueryAddress = require('../../src/types/FateOracleQueryAddress')
+const FateOracleQueryAddressRaw = require('../../src/types/FateOracleQueryAddressRaw')
 
 const s = new OracleQuerySerializer()
 
 test('Serialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.serialize(new FateOracleQueryAddress("0xfedcba9876543210")),
-        [159,4,136,254,220,186,152,118,84,50,16]
+        s.serialize(new FateOracleQueryAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,4,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,118,
+            84,50,16,254,220,186,152,118,84,50,16]
     )
 
     t.deepEqual(
@@ -21,8 +23,9 @@ test('Serialize', t => {
 test('Deserialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.deserialize([159,4,136,254,220,186,152,118,84,50,16]),
-        new FateOracleQueryAddress("0xfedcba9876543210")
+        s.deserialize([159,4,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,
+            186,152,118,84,50,16,254,220,186,152,118,84,50,16]),
+        new FateOracleQueryAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")
     )
 
     t.is(

--- a/tests/Serializers/OracleSerializer.js
+++ b/tests/Serializers/OracleSerializer.js
@@ -1,14 +1,16 @@
 const test = require('../test')
 const OracleSerializer = require('../../src/Serializers/OracleSerializer')
 const FateOracleAddress = require('../../src/types/FateOracleAddress')
+const FateOracleAddressRaw = require('../../src/types/FateOracleAddressRaw')
 
 const s = new OracleSerializer()
 
 test('Serialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.serialize(new FateOracleAddress("0xfedcba9876543210")),
-        [159,3,136,254,220,186,152,118,84,50,16]
+        s.serialize(new FateOracleAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")),
+        [159,3,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,186,152,
+            118,84,50,16,254,220,186,152,118,84,50,16]
     )
 
     t.deepEqual(
@@ -21,8 +23,9 @@ test('Serialize', t => {
 test('Deserialize', t => {
     t.plan(2)
     t.deepEqual(
-        s.deserialize([159,3,136,254,220,186,152,118,84,50,16]),
-        new FateOracleAddress("0xfedcba9876543210")
+        s.deserialize([159,3,160,254,220,186,152,118,84,50,16,254,220,186,152,118,84,50,16,254,220,
+            186,152,118,84,50,16,254,220,186,152,118,84,50,16]),
+        new FateOracleAddressRaw("0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210")
     )
 
     t.is(


### PR DESCRIPTION
I'm proposing to
- ensure that address length is correct to faster find errors
- accept only ae-encoded addresses to simplify interface and validation (still able to create addresses internally as byte arrays (to avoid extra encoding/decoding) by passing `raw` flag)