### PR TITLE
Accept object as map

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,21 @@ Expected output:
 
 Using the library involves data types and their mappings from Sophia to JavaScript and vice versa.
 
-| Sophia Type         | Sophia Example                                              | Javascript type | Javascript Example                                                             |
-| ------------------- | -----------                                                 | --------------- | -----------                                                                    |
-| int                 | `63`, `-63`                                                 | BigInt          | `63n`, `-63n`                                                                  |
-| bool                | `true`, `false`                                             | Boolean         | `true`, `false`                                                                |
-| string              | `"whoolymoly"`                                              | String          | `"whoolymoly"`                                                                 |
-| bytes               | `#beef`                                                     | BigInt          | `BigInt("0xbeef")`                                                             |
-| list                | `[1, 2, 3, 5, 8, 13, 21]`                                   | Array           | `[1,2,3,5,8,13,21]`                                                            |
-| tuple               | `(true, false)`                                             | Array           | `[true, false]`                                                                |
-| map                 | `{[7] = false}`                                             | Map             | `new Map([[7, false]])`                                                        |
-| record              | `{x = 0, y = 0}`                                            | Object (POJO)   | `{x: 0, y: 0}`                                                                 |
-| variant             | `Some(404)`, `None`                                         | Object (POJO)   | `{'Some': [404]}`, `{'None': []}`, `404`, `undefined`                          |
-| bits                | `Bits.none`, `Bits.all`  `Bits.set(Bits.none, 0)`           | BigInt          | `0b0n`, `-1n`, `0b00000001n`                                                   |
-| hash                | `#001234d`                                                  | BigInt          | `BigInt("0x001234d")`                                                          |
-| signature           | `#001234d`                                                  | BigInt          | `BigInt("0x001234d")`                                                          |
-| address             | `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt`     | String          | `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt`                        |
+| Sophia Type | Sophia Example                                          | Javascript type    | Javascript Example                                      |
+|-------------|---------------------------------------------------------|--------------------|---------------------------------------------------------|
+| int         | `63`, `-63`                                             | BigInt             | `63n`, `-63n`                                           |
+| bool        | `true`, `false`                                         | Boolean            | `true`, `false`                                         |
+| string      | `"whoolymoly"`                                          | String             | `"whoolymoly"`                                          |
+| bytes       | `#beef`                                                 | BigInt             | `BigInt("0xbeef")`                                      |
+| list        | `[1, 2, 3, 5, 8, 13, 21]`                               | Array              | `[1,2,3,5,8,13,21]`                                     |
+| tuple       | `(true, false)`                                         | Array              | `[true, false]`                                         |
+| map         | `{[7] = false}`                                         | Map, Object, Array | `new Map([[7, false]])`, `{7: false}`, `[[7, false]]`   |
+| record      | `{x = 0, y = 0}`                                        | Object (POJO)      | `{x: 0, y: 0}`                                          |
+| variant     | `Some(404)`, `None`                                     | Object (POJO)      | `{'Some': [404]}`, `{'None': []}`, `404`, `undefined`   |
+| bits        | `Bits.none`, `Bits.all`  `Bits.set(Bits.none, 0)`       | BigInt             | `0b0n`, `-1n`, `0b00000001n`                            |
+| hash        | `#001234d`                                              | BigInt             | `BigInt("0x001234d")`                                   |
+| signature   | `#001234d`                                              | BigInt             | `BigInt("0x001234d")`                                   |
+| address     | `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt` | String             | `ak_2gx9MEFxKvY9vMG5YnqnXWv1hCsX7rgnfvBLJS4aQurustR1rt` |
 
 - note the fixed structure of variant object with a single key - the variant constructor (i.e. `Some`) and array of variant arguments as it's value.
 - while Javascript Number and primitive `int` types can be used as well when `BigInt` type is expected it's not recommended because of it's `Number.MAX_SAFE_INTEGER` limitation.

--- a/src/Mapper/InternalMapper.js
+++ b/src/Mapper/InternalMapper.js
@@ -23,6 +23,8 @@ class InternalMapper {
             return this.toAddress(type, value)
         case 'variant':
             return this.toVariant(type, value)
+        case 'map':
+            return this.toMap(type, value)
         default:
             return value
         }
@@ -62,6 +64,17 @@ class InternalMapper {
     isOptionVariant({ _name, variants }) {
         return variants.some(({ None }) => None && None.length === 0)
             && variants.some(({ Some }) => Some)
+    }
+
+    toMap(type, value) {
+        if (typeof value !== 'object' || value === null) {
+            throw new FateTypeError(
+                'map',
+                `Fate map must be one of: Map, Array, Object; got ${value} instead`
+            )
+        }
+
+        return Array.isArray(value) || value instanceof Map ? value : Object.entries(value)
     }
 }
 

--- a/tests/Encoder.js
+++ b/tests/Encoder.js
@@ -216,6 +216,23 @@ test('Encode map arguments', t => {
     t.is(encoded, 'cb_KxHLN316Gy8BDn+vbmBO', 'test_simple_map({[7] = false})')
 })
 
+test('Encode map arguments by object', t => {
+    t.plan(1)
+    const encoded = encoder.encode(CONTRACT, 'test_simple_map', [{ 7: false }])
+    t.is(encoded, 'cb_KxHLN316Gy8BDn+vbmBO', 'test_simple_map({[7] = false})')
+})
+
+test('Ensures map is map, array, object', t => {
+    t.plan(1)
+    t.throws(
+        () => encoder.encode(CONTRACT, 'test_simple_map', ['test-string']),
+        {
+            name: 'FateTypeError',
+            message: 'Fate map must be one of: Map, Array, Object; got test-string instead'
+        }
+    )
+})
+
 test('Encode nested map arguments', t => {
     t.plan(1)
     const encoded = encoder.encode(CONTRACT, 'test_nested_map', [[


### PR DESCRIPTION
SDK was accepting objects as maps before calldata, it looks useful to me, so I'm proposing to support this.
https://github.com/aeternity/aepp-sdk-js/blob/bc65bd78ecd6f8876c0642b11c6ba0aa1f5e4598/docs/guides/contracts.md#sophia-datatype-cheatsheet