### PR TITLE
Add support for FATE data encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,30 @@ Decoded string: whoolymoly
 Decoded map: Map(1) { 7n => false }
 ```
 
+The encoder could also work with explicit type information:
+
+Example:
+```javascript
+const {ContractByteArrayEncoder, TypeResolver} = require('@aeternity/aepp-calldata')
+
+const encoder = new ContractByteArrayEncoder()
+const resolver = new TypeResolver()
+
+const decodedString = encoder.decodeWithType('cb_KXdob29seW1vbHlGazSE', resolver.resolveType('string'))
+console.log(`Decoded string: ${decodedString}`)
+
+const type = resolver.resolveType({map: ['int', 'bool']})
+const encodedMap = encoder.encodeWithType(new Map([[7n, false]]), type)
+console.log('Encoded map:', encodedMap)
+
+```
+
+Expected output:
+```
+Decoded string: whoolymoly
+Decoded map: Map(1) { 7n => false }
+```
+
 ## FATE API Encoder
 
 Any of the following FATE API data types can be encoded and decoded:
@@ -287,15 +311,16 @@ Refer to the [CHANGELOG](CHANGELOG.md) for more information about releases.
 The backward compatibility promise signaled with semantic versioning [above](#versioning) is **only** applied to public API of this library,
 that is only the module exports and [data types](#data-types) listed above.
 
-The public API namely consist of:
+The public API namely consist of below classes:
 
-`AciContractCallEncoder` class:
+- [AciContractCallEncoder](./api/AciContractCallEncoder.js)
+- [BytecodeContractCallEncoder](./api/BytecodeContractCallEncoder.js)
+- [ContractByteArrayEncoder](./api/ContractByteArrayEncoder.js)
+- [FateApiEncoder](./api/FateApiEncoder.js)
+- [ContractEncoder](./api/ContractEncoder.js)
+- [TypeResolver](./api/TypeResolver.js)
 
-- `encodeCall(contractName: string, functionName: string, arguments: Array<Data>): string`
-- `decodeResult(contractName: string, functionName: string, data: string, resultType: string): Data`
-- `decodeEvent(contractName: string, data: string, topics: Array<BigInt>): string`
-
-where `Data: Boolean | BigInt | String | Array | Map | Set | Object`
+The public API is also defined in [TypeScript declation file](main.d.ts).
 
 ### Errors
 

--- a/src/AciTypeResolver.js
+++ b/src/AciTypeResolver.js
@@ -1,34 +1,6 @@
+const TypeResolver = require('./TypeResolver')
 const TypeResolveError = require('./Errors/TypeResolveError')
-const {
-    FateTypeVoid,
-    FateTypeInt,
-    FateTypeBool,
-    FateTypeString,
-    FateTypeBits,
-    FateTypeBytes,
-    FateTypeHash,
-    FateTypeSignature,
-    FateTypeAccountAddress,
-    FateTypeContractAddress,
-    FateTypeOracleAddress,
-    FateTypeOracleQueryAddress,
-    FateTypeList,
-    FateTypeMap,
-    FateTypeTuple,
-    FateTypeRecord,
-    FateTypeSet,
-    FateTypeVariant,
-    FateTypeOption,
-    FateTypeChainTTL,
-    FateTypeChainGAMetaTx,
-    FateTypeChainPayingForTx,
-    FateTypeChainBaseTx,
-    FateTypeAENSPointee,
-    FateTypeAENSName,
-    FateTypeEvent,
-    FateTypeBls12381Fr,
-    FateTypeBls12381Fp
-} = require('./FateTypes')
+const {FateTypeEvent} = require('./FateTypes')
 
 const isObject = (value) => {
     return value && typeof value === 'object' && value.constructor === Object
@@ -44,8 +16,10 @@ const isOption = ({type}) => {
     return key === 'option'
 }
 
-class AciTypeResolver {
+class AciTypeResolver extends TypeResolver {
     constructor(aci) {
+        super()
+
         this.aci = aci
     }
 
@@ -124,170 +98,6 @@ class AciTypeResolver {
         }
 
         return null
-    }
-
-    resolveType(type, vars = {}) {
-        let key = type
-        let valueTypes = []
-        let resolvedTypes = []
-
-        if (isObject(type)) {
-            [[key, valueTypes]] = Object.entries(type)
-        }
-
-        if (this.isCustomType(key)) {
-            const [typeDef, typeVars] = this.resolveTypeDef(key, valueTypes)
-
-            return this.resolveType(typeDef, typeVars)
-        }
-
-        if (Array.isArray(valueTypes)) {
-            if (key !== 'variant') {
-                resolvedTypes = valueTypes.map(v => {
-                    const tpl = v.hasOwnProperty('type') ? v.type : v
-                    const t = vars.hasOwnProperty(tpl) ? vars[tpl] : tpl
-
-                    return this.resolveType(t, vars)
-                })
-            }
-        }
-
-        if (key === 'void') {
-            return FateTypeVoid()
-        }
-
-        if (key === 'unit') {
-            return FateTypeTuple([])
-        }
-
-        if (key === 'int') {
-            return FateTypeInt()
-        }
-
-        if (key === 'bool') {
-            return FateTypeBool()
-        }
-
-        if (key === 'string') {
-            return FateTypeString()
-        }
-
-        if (key === 'bits') {
-            return FateTypeBits()
-        }
-
-        if (key === 'hash') {
-            return FateTypeHash()
-        }
-
-        if (key === 'signature') {
-            return FateTypeSignature()
-        }
-
-        if (key === 'address') {
-            return FateTypeAccountAddress()
-        }
-
-        if (key === 'contract_pubkey') {
-            return FateTypeContractAddress()
-        }
-
-        if (key === 'Chain.ttl') {
-            return FateTypeChainTTL()
-        }
-
-        if (key === 'Chain.ga_meta_tx') {
-            return FateTypeChainGAMetaTx()
-        }
-
-        if (key === 'Chain.paying_for_tx') {
-            return FateTypeChainPayingForTx()
-        }
-
-        if (key === 'Chain.base_tx') {
-            return FateTypeChainBaseTx()
-        }
-
-        if (key === 'AENS.pointee') {
-            return FateTypeAENSPointee()
-        }
-
-        if (key === 'AENS.name') {
-            return FateTypeAENSName()
-        }
-
-        if (key === 'Set.set') {
-            return FateTypeSet(...resolvedTypes)
-        }
-
-        if (key === 'MCL_BLS12_381.fr') {
-            return FateTypeBls12381Fr()
-        }
-
-        if (key === 'MCL_BLS12_381.fp') {
-            return FateTypeBls12381Fp()
-        }
-
-        if (key === 'bytes') {
-            return FateTypeBytes(valueTypes)
-        }
-
-        if (key === 'list') {
-            return FateTypeList(...resolvedTypes)
-        }
-
-        if (key === 'map') {
-            return FateTypeMap(...resolvedTypes)
-        }
-
-        // Unbox singleton tuples and records
-        // https://github.com/aeternity/aesophia/pull/205
-        // https://github.com/aeternity/aesophia/commit/a403a9d227ac56266cf5bb8fbc916f17e6141d15
-        if ((key === 'tuple' || key === 'record') && resolvedTypes.length === 1) {
-            return resolvedTypes[0]
-        }
-
-        if (key === 'tuple') {
-            return FateTypeTuple(resolvedTypes)
-        }
-
-        if (key === 'record') {
-            const keys = valueTypes.map(e => e.name)
-
-            return FateTypeRecord(keys, resolvedTypes)
-        }
-
-        if (key === 'variant') {
-            return this.resolveVariant(valueTypes, vars)
-        }
-
-        if (key === 'option') {
-            return FateTypeOption(resolvedTypes)
-        }
-
-        if (key === 'oracle') {
-            return FateTypeOracleAddress(...resolvedTypes)
-        }
-
-        if (key === 'oracle_query') {
-            return FateTypeOracleQueryAddress(...resolvedTypes)
-        }
-
-        throw new TypeResolveError('Cannot resolve type: ' + JSON.stringify(type))
-    }
-
-    resolveVariant(valueTypes, vars) {
-        const variants = valueTypes.map(e => {
-            const [[variant, args]] = Object.entries(e)
-            const resolvedArgs = args.map(v => {
-                const t = vars.hasOwnProperty(v) ? vars[v] : v
-                return this.resolveType(t, vars)
-            })
-
-            return {[variant]: resolvedArgs}
-        })
-
-        return FateTypeVariant(variants)
     }
 
     resolveTypeDef(type, params = []) {

--- a/src/ContractByteArrayEncoder.js
+++ b/src/ContractByteArrayEncoder.js
@@ -22,11 +22,12 @@ class ContractByteArrayEncoder {
      * Encode FATE data to contract bytearray.
      *
      * @example
-     * const encoded = encoder.encode("whoolymoly")
+     * const encoded = encoder.encode(FateTypeString(), "whoolymoly")
      * console.log(`Encoded data: ${encoded}`)
      * // Outputs:
      * // Encoded data: cb_KXdob29seW1vbHlGazSE
      *
+     * @param {object} type - Data as Javascript data structures. See README.md
      * @param {Array} data - Data as Javascript data structures. See README.md
      * @returns {string} Encoded contract byte array
     */
@@ -68,12 +69,13 @@ class ContractByteArrayEncoder {
      * Decodes arbitrary contract bytearray data with type information.
      *
      * @example
-     * const decoded = encoder.decode('cb_KXdob29seW1vbHlGazSE')
+     * const decoded = encoder.decodeWithType('cb_KXdob29seW1vbHlGazSE', FateTypeString())
      * console.log(`Decoded data: ${decoded}`)
      * // Outputs:
      * // Decoded data: whoolymoly
      *
      * @param {string} data - Contract bytearray data in a canonical format.
+     * @param {object} type - Data as Javascript data structures. See README.md
      * @returns {boolean|string|BigInt|Array|Map|Object}
      *  Decoded value as Javascript data structures. See README.md
     */

--- a/src/TypeResolver.js
+++ b/src/TypeResolver.js
@@ -1,0 +1,217 @@
+const TypeResolveError = require('./Errors/TypeResolveError')
+const {
+    FateTypeVoid,
+    FateTypeInt,
+    FateTypeBool,
+    FateTypeString,
+    FateTypeBits,
+    FateTypeBytes,
+    FateTypeHash,
+    FateTypeSignature,
+    FateTypeAccountAddress,
+    FateTypeContractAddress,
+    FateTypeOracleAddress,
+    FateTypeOracleQueryAddress,
+    FateTypeList,
+    FateTypeMap,
+    FateTypeTuple,
+    FateTypeRecord,
+    FateTypeSet,
+    FateTypeVariant,
+    FateTypeOption,
+    FateTypeChainTTL,
+    FateTypeChainGAMetaTx,
+    FateTypeChainPayingForTx,
+    FateTypeChainBaseTx,
+    FateTypeAENSPointee,
+    FateTypeAENSName,
+    FateTypeBls12381Fr,
+    FateTypeBls12381Fp
+} = require('./FateTypes')
+
+const isObject = (value) => {
+    return value && typeof value === 'object' && value.constructor === Object
+}
+
+class TypeResolver {
+    isCustomType() {
+        return false
+    }
+
+    resolveTypeDef(type, valueTypes) {
+        return [type, valueTypes]
+    }
+
+    resolveValueTypes(valueTypes, vars) {
+        if (!Array.isArray(valueTypes)) {
+            return []
+        }
+
+        return valueTypes.map(v => {
+            const tpl = v.hasOwnProperty('type') ? v.type : v
+            const t = vars.hasOwnProperty(tpl) ? vars[tpl] : tpl
+
+            return this.resolveType(t, vars)
+        })
+    }
+
+    resolveType(type, vars = {}) {
+        let key = type
+        let valueTypes = []
+        let resolvedTypes = []
+
+        if (isObject(type)) {
+            [[key, valueTypes]] = Object.entries(type)
+        }
+
+        if (this.isCustomType(key)) {
+            const [typeDef, typeVars] = this.resolveTypeDef(key, valueTypes)
+
+            return this.resolveType(typeDef, typeVars)
+        }
+
+        // variant value types are resolved in its own method
+        if (key !== 'variant') {
+            resolvedTypes = this.resolveValueTypes(valueTypes, vars)
+        }
+
+        if (key === 'void') {
+            return FateTypeVoid()
+        }
+
+        if (key === 'unit') {
+            return FateTypeTuple([])
+        }
+
+        if (key === 'int') {
+            return FateTypeInt()
+        }
+
+        if (key === 'bool') {
+            return FateTypeBool()
+        }
+
+        if (key === 'string') {
+            return FateTypeString()
+        }
+
+        if (key === 'bits') {
+            return FateTypeBits()
+        }
+
+        if (key === 'hash') {
+            return FateTypeHash()
+        }
+
+        if (key === 'signature') {
+            return FateTypeSignature()
+        }
+
+        if (key === 'address') {
+            return FateTypeAccountAddress()
+        }
+
+        if (key === 'contract_pubkey') {
+            return FateTypeContractAddress()
+        }
+
+        if (key === 'Chain.ttl') {
+            return FateTypeChainTTL()
+        }
+
+        if (key === 'Chain.ga_meta_tx') {
+            return FateTypeChainGAMetaTx()
+        }
+
+        if (key === 'Chain.paying_for_tx') {
+            return FateTypeChainPayingForTx()
+        }
+
+        if (key === 'Chain.base_tx') {
+            return FateTypeChainBaseTx()
+        }
+
+        if (key === 'AENS.pointee') {
+            return FateTypeAENSPointee()
+        }
+
+        if (key === 'AENS.name') {
+            return FateTypeAENSName()
+        }
+
+        if (key === 'Set.set') {
+            return FateTypeSet(...resolvedTypes)
+        }
+
+        if (key === 'MCL_BLS12_381.fr') {
+            return FateTypeBls12381Fr()
+        }
+
+        if (key === 'MCL_BLS12_381.fp') {
+            return FateTypeBls12381Fp()
+        }
+
+        if (key === 'bytes') {
+            return FateTypeBytes(valueTypes)
+        }
+
+        if (key === 'list') {
+            return FateTypeList(...resolvedTypes)
+        }
+
+        if (key === 'map') {
+            return FateTypeMap(...resolvedTypes)
+        }
+
+        // Unbox singleton tuples and records
+        // https://github.com/aeternity/aesophia/pull/205
+        // https://github.com/aeternity/aesophia/commit/a403a9d227ac56266cf5bb8fbc916f17e6141d15
+        if ((key === 'tuple' || key === 'record') && resolvedTypes.length === 1) {
+            return resolvedTypes[0]
+        }
+
+        if (key === 'tuple') {
+            return FateTypeTuple(resolvedTypes)
+        }
+
+        if (key === 'record') {
+            const keys = valueTypes.map(e => e.name)
+
+            return FateTypeRecord(keys, resolvedTypes)
+        }
+
+        if (key === 'variant') {
+            return this.resolveVariant(valueTypes, vars)
+        }
+
+        if (key === 'option') {
+            return FateTypeOption(resolvedTypes)
+        }
+
+        if (key === 'oracle') {
+            return FateTypeOracleAddress(...resolvedTypes)
+        }
+
+        if (key === 'oracle_query') {
+            return FateTypeOracleQueryAddress(...resolvedTypes)
+        }
+
+        throw new TypeResolveError('Cannot resolve type: ' + JSON.stringify(type))
+    }
+
+    resolveVariant(valueTypes, vars) {
+        const variants = valueTypes.map(e => {
+            const [[variant, args]] = Object.entries(e)
+            const resolvedArgs = args.map(v => {
+                const t = vars.hasOwnProperty(v) ? vars[v] : v
+                return this.resolveType(t, vars)
+            })
+
+            return {[variant]: resolvedArgs}
+        })
+
+        return FateTypeVariant(variants)
+    }
+}
+
+module.exports = TypeResolver

--- a/src/api/ContractByteArrayEncoder.js
+++ b/src/api/ContractByteArrayEncoder.js
@@ -6,7 +6,25 @@ class ContractByteArrayEncoder {
     }
 
     /**
-     * Decodes arbitrary contract bytearray data.
+     * Encode FATE data to contract bytearray.
+     *
+     * @example
+     * const resolver = new TypeResolver()
+     * const encoded = encoder.encode("whoolymoly", resolver.resolveType('string'))
+     * console.log(`Encoded data: ${encoded}`)
+     * // Outputs:
+     * // Encoded data: cb_KXdob29seW1vbHlGazSE
+     *
+     * @param {any} value - Value as Javascript data structures. See README.md
+     * @param {object} type - Opaque type information provided by TypeResolver. See README.md
+     * @returns {string} Encoded contract byte array
+    */
+    encodeWithType(value, type) {
+        return this._internalEncoder.encode(type, value)
+    }
+
+    /**
+     * Decodes arbitrary contract bytearray data using only builtin FATE type information
      *
      * Note that:
      * - Variants are not annotated with constructor names
@@ -26,6 +44,26 @@ class ContractByteArrayEncoder {
     */
     decode(data) {
         return this._internalEncoder.decode(data)
+    }
+
+    /**
+     * Decodes arbitrary contract bytearray data with type information.
+     *
+     * @example
+     * const resolver = new TypeResolver()
+     * const type = resolver.resolveType('string')
+     * const decoded = encoder.decodeWithType('cb_KXdob29seW1vbHlGazSE', type)
+     * console.log(`Decoded data: ${decoded}`)
+     * // Outputs:
+     * // Decoded data: whoolymoly
+     *
+     * @param {string} data - Contract bytearray data in a canonical format.
+     * @param {object} type - Opaque type information provided by TypeResolver. See README.md
+     * @returns {boolean|string|BigInt|Array|Map|Object}
+     *  Decoded value as Javascript data structures. See README.md
+    */
+    decodeWithType(data, type) {
+        return this._internalEncoder.decodeWithType(data, type)
     }
 }
 

--- a/src/api/TypeResolver.js
+++ b/src/api/TypeResolver.js
@@ -1,0 +1,30 @@
+const InternalResolver = require('../TypeResolver')
+
+class TypeResolver {
+    constructor() {
+        this._internalResolver = new InternalResolver()
+    }
+
+    /**
+     * Resolves ACI type format to opaque (internal) type structure
+     * to allow usage of other library APIs that needs type information.
+     * The opaque type shouldn't be used for anything else (including storing) than passing it
+     * as library argument as its structure is not guaranteed.
+     *
+     * @example
+     * const type = resolver.resolveType({map: ['int', 'bool']})
+     * const encoded = ContractByteArrayEncoder.encode(new Map([[7n, false]]), type)
+     * console.log(`Encoded data: ${encoded}`)
+     * // Outputs:
+     * // Encoded data: cb_LwEOfzGit9U=
+     *
+     * @param {object} type - The type information in ACI format
+     * @param {object} vars - Additional type variables, templates etc.
+     * @returns {object} Opaque type information structure
+    */
+    resolveType(type, vars = {}) {
+        return this._internalResolver.resolveType(type, vars)
+    }
+}
+
+module.exports = TypeResolver

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -57,7 +57,9 @@ export class BytecodeContractCallEncoder {
 }
 
 export class ContractByteArrayEncoder {
+  encodeWithType(value: any, type: object): `cb_${string}`;
   decode(data: `cb_${string}`): any;
+  decodeWithType(data: `cb_${string}`, type: object): any;
 }
 
 declare type TYPE2TAG = {
@@ -76,4 +78,8 @@ export class FateApiEncoder {
 
 export class ContractEncoder {
   decode(data: `cb_${string}`): object;
+}
+
+export class TypeResolver {
+  resolveType(type: string|object, vars: object): object;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ const BytecodeContractCallEncoder = require('./api/BytecodeContractCallEncoder')
 const ContractByteArrayEncoder = require('./api/ContractByteArrayEncoder')
 const FateApiEncoder = require('./api/FateApiEncoder')
 const ContractEncoder = require('./api/ContractEncoder')
+const TypeResolver = require('./api/TypeResolver')
 
 module.exports = {
     Encoder,
@@ -12,4 +13,5 @@ module.exports = {
     ContractByteArrayEncoder,
     FateApiEncoder,
     ContractEncoder,
+    TypeResolver,
 }

--- a/tests/AciTypeResolver.js
+++ b/tests/AciTypeResolver.js
@@ -5,22 +5,10 @@ const {
     FateTypeInt,
     FateTypeBool,
     FateTypeString,
-    FateTypeBits,
-    FateTypeBytes,
-    FateTypeHash,
-    FateTypeSignature,
-    FateTypeAccountAddress,
     FateTypeContractAddress,
-    FateTypeOracleAddress,
-    FateTypeOracleQueryAddress,
-    FateTypeList,
-    FateTypeMap,
     FateTypeTuple,
     FateTypeRecord,
     FateTypeVariant,
-    FateTypeOption,
-    FateTypeChainTTL,
-    FateTypeAENSPointee
 } = require('../src/FateTypes')
 
 const CONTRACT = 'Test'
@@ -54,75 +42,11 @@ test('Get function return type', t => {
     )
 })
 
-test('Resolve unit', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('unit'),
-        FateTypeTuple()
-    )
-})
-
 test('Return type unit', t => {
     t.plan(1)
     t.deepEqual(
         resolver.getReturnType(CONTRACT, 'test_unit'),
         FateTypeTuple()
-    )
-})
-
-test('Resolve bool', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('bool'),
-        FateTypeBool()
-    )
-})
-
-test('Resolve int', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('int'),
-        FateTypeInt()
-    )
-})
-
-test('Resolve string', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('string'),
-        FateTypeString()
-    )
-})
-
-test('Resolve bits', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('bits'),
-        FateTypeBits()
-    )
-})
-
-test('Resolve hash', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('hash'),
-        FateTypeHash()
-    )
-})
-
-test('Resolve signature', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('signature'),
-        FateTypeSignature()
-    )
-})
-
-test('Resolve account address', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('address'),
-        FateTypeAccountAddress()
     )
 })
 
@@ -134,83 +58,11 @@ test('Resolve contract address', t => {
     )
 })
 
-test('Resolve oracle address', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({oracle: ['int', 'string']}),
-        FateTypeOracleAddress(FateTypeInt(), FateTypeString())
-    )
-})
-
-test('Resolve oracle query address', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({oracle_query: ['int', 'string']}),
-        FateTypeOracleQueryAddress(FateTypeInt(), FateTypeString())
-    )
-})
-
-test('Resolve bytes', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({bytes: 32}),
-        FateTypeBytes(32)
-    )
-})
-
 test('Resolve type defs', t => {
     t.plan(1)
     t.deepEqual(
         resolver.resolveType('Test.number'),
         FateTypeInt()
-    )
-})
-
-test('Resolve list', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({list: ['int']}),
-        FateTypeList(FateTypeInt())
-    )
-})
-
-test('Resolve templated list', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({list: ["'a"]}, {"'a": "int"}),
-        FateTypeList(FateTypeInt())
-    )
-})
-
-test('Resolve map', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({map: ['int', 'bool']}),
-        FateTypeMap(FateTypeInt(), FateTypeBool())
-    )
-})
-
-test('Resolve templated map', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({map: ["'a", 'string']}, {"'a": 'int'}),
-        FateTypeMap(FateTypeInt(), FateTypeString())
-    )
-})
-
-test('Resolve tuple', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({tuple: ['int', 'bool']}),
-        FateTypeTuple([FateTypeInt(), FateTypeBool()])
-    )
-})
-
-test('Resolve templated tuple', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({tuple: ["'a", "'b"]}, {"'a": 'int', "'b": 'bool'}),
-        FateTypeTuple([FateTypeInt(), FateTypeBool()])
     )
 })
 
@@ -258,30 +110,6 @@ test('Resolve variant with template vars', t => {
             {Zero: []},
             {Any: [FateTypeInt(), FateTypeBool(), FateTypeInt(), FateTypeInt()]}
         ])
-    )
-})
-
-test('Resolve Option', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType({option: ['int']}),
-        FateTypeOption([FateTypeInt()])
-    )
-})
-
-test('Resolve Chain.ttl', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('Chain.ttl'),
-        FateTypeChainTTL()
-    )
-})
-
-test('Resolve AENS.pointee', t => {
-    t.plan(1)
-    t.deepEqual(
-        resolver.resolveType('AENS.pointee'),
-        FateTypeAENSPointee()
     )
 })
 

--- a/tests/TypeResolver.js
+++ b/tests/TypeResolver.js
@@ -1,0 +1,372 @@
+const test = require('./test')
+const TypeResolver = require('../src/TypeResolver')
+
+const {
+    FateTypeVoid,
+    FateTypeInt,
+    FateTypeBool,
+    FateTypeString,
+    FateTypeBits,
+    FateTypeBytes,
+    FateTypeHash,
+    FateTypeSignature,
+    FateTypeAccountAddress,
+    FateTypeContractAddress,
+    FateTypeOracleAddress,
+    FateTypeOracleQueryAddress,
+    FateTypeList,
+    FateTypeMap,
+    FateTypeTuple,
+    FateTypeRecord,
+    FateTypeVariant,
+    FateTypeOption,
+    FateTypeChainTTL,
+    FateTypeChainGAMetaTx,
+    FateTypeChainPayingForTx,
+    FateTypeChainBaseTx,
+    FateTypeAENSPointee,
+    FateTypeAENSName,
+    FateTypeSet,
+    FateTypeBls12381Fr,
+    FateTypeBls12381Fp,
+} = require('../src/FateTypes')
+
+const resolver = new TypeResolver()
+
+test('Resolve void', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('void'),
+        FateTypeVoid()
+    )
+})
+
+test('Resolve unit', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('unit'),
+        FateTypeTuple()
+    )
+})
+
+test('Resolve bool', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('bool'),
+        FateTypeBool()
+    )
+})
+
+test('Resolve int', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('int'),
+        FateTypeInt()
+    )
+})
+
+test('Resolve string', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('string'),
+        FateTypeString()
+    )
+})
+
+test('Resolve bits', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('bits'),
+        FateTypeBits()
+    )
+})
+
+test('Resolve hash', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('hash'),
+        FateTypeHash()
+    )
+})
+
+test('Resolve signature', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('signature'),
+        FateTypeSignature()
+    )
+})
+
+test('Resolve account address', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('address'),
+        FateTypeAccountAddress()
+    )
+})
+
+test('Resolve contract address', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('contract_pubkey'),
+        FateTypeContractAddress()
+    )
+})
+
+test('Resolve oracle address', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({oracle: ['int', 'string']}),
+        FateTypeOracleAddress(FateTypeInt(), FateTypeString())
+    )
+})
+
+test('Resolve oracle query address', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({oracle_query: ['int', 'string']}),
+        FateTypeOracleQueryAddress(FateTypeInt(), FateTypeString())
+    )
+})
+
+test('Resolve bytes', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({bytes: 32}),
+        FateTypeBytes(32)
+    )
+})
+
+test('Resolve list', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({list: ['int']}),
+        FateTypeList(FateTypeInt())
+    )
+})
+
+test('Resolve templated list', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({list: ["'a"]}, {"'a": "int"}),
+        FateTypeList(FateTypeInt())
+    )
+})
+
+test('Resolve map', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({map: ['int', 'bool']}),
+        FateTypeMap(FateTypeInt(), FateTypeBool())
+    )
+})
+
+test('Resolve templated map', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({map: ["'a", 'string']}, {"'a": 'int'}),
+        FateTypeMap(FateTypeInt(), FateTypeString())
+    )
+})
+
+test('Resolve tuple', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({tuple: ['int', 'bool']}),
+        FateTypeTuple([FateTypeInt(), FateTypeBool()])
+    )
+})
+
+test('Resolve unboxed singleton tuple', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({tuple: ['int']}),
+        FateTypeInt()
+    )
+})
+
+test('Resolve templated tuple', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({tuple: ["'a", "'b"]}, {"'a": 'int', "'b": 'bool'}),
+        FateTypeTuple([FateTypeInt(), FateTypeBool()])
+    )
+})
+
+test('Resolve record', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({
+            record: [
+                {name: 'x', type: 'int'},
+                {name: 'y', type: 'int'}
+            ]
+        }),
+        FateTypeRecord(
+            ['x', 'y'],
+            [FateTypeInt(), FateTypeInt()]
+        )
+    )
+})
+
+test('Resolve unboxed singleton record', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({record: [{name: 'x', type: 'int'}]}),
+        FateTypeInt()
+    )
+})
+
+test('Resolve nested record', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({
+            record: [
+                {
+                    name: 'origin',
+                    type: {
+                        record: [
+                            {name: 'x', type: 'int'},
+                            {name: 'y', type: 'int'}
+                        ]
+                    }
+                },
+                {name: 'a', type: 'int'},
+                {name: 'b', type: 'int'},
+            ]
+        }),
+        FateTypeRecord(
+            ['origin', 'a', 'b'],
+            [
+                FateTypeRecord(['x', 'y'], [FateTypeInt(), FateTypeInt()]),
+                FateTypeInt(),
+                FateTypeInt()
+            ],
+        )
+    )
+})
+
+test('Resolve variant', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({
+            variant: [
+                {Nope: []},
+                {No: []},
+                {Yep: ['int']},
+                {Yes: []}
+            ]
+        }),
+        FateTypeVariant([{Nope: []}, {No: []}, {Yep: [FateTypeInt()]}, {Yes: []}])
+    )
+})
+
+test('Resolve variant with template vars', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType(
+            {
+                variant: [
+                    {Zero: []},
+                    {Any: ["'a", "'b", 'int', 'int']},
+                ]
+            },
+            {"'a": 'int', "'b": 'bool'}
+        ),
+        FateTypeVariant([
+            {Zero: []},
+            {Any: [FateTypeInt(), FateTypeBool(), FateTypeInt(), FateTypeInt()]}
+        ])
+    )
+})
+
+test('Resolve Option', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({option: ['int']}),
+        FateTypeOption([FateTypeInt()])
+    )
+})
+
+test('Resolve Chain.ttl', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('Chain.ttl'),
+        FateTypeChainTTL()
+    )
+})
+
+test('Resolve Chain.ga_meta_tx', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('Chain.ga_meta_tx'),
+        FateTypeChainGAMetaTx()
+    )
+})
+
+test('Resolve Chain.paying_for_tx', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('Chain.paying_for_tx'),
+        FateTypeChainPayingForTx()
+    )
+})
+
+test('Resolve Chain.base_tx', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('Chain.base_tx'),
+        FateTypeChainBaseTx()
+    )
+})
+
+test('Resolve AENS.pointee', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('AENS.pointee'),
+        FateTypeAENSPointee()
+    )
+})
+
+test('Resolve AENS.name', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('AENS.name'),
+        FateTypeAENSName()
+    )
+})
+
+test('Resolve Set.set', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType({'Set.set': ['int']}),
+        FateTypeSet(FateTypeInt())
+    )
+})
+
+test('Resolve MCL_BLS12_381.fr', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('MCL_BLS12_381.fr'),
+        FateTypeBls12381Fr()
+    )
+})
+
+test('Resolve MCL_BLS12_381.fp', t => {
+    t.plan(1)
+    t.deepEqual(
+        resolver.resolveType('MCL_BLS12_381.fp'),
+        FateTypeBls12381Fp()
+    )
+})
+
+test('Throws on invalid type', t => {
+    t.plan(1)
+    t.throws(
+        () => resolver.resolveType('very_wrong_type'),
+        {
+            name: 'TypeResolveError',
+            message: `Cannot resolve type: "very_wrong_type"`
+        }
+    )
+})

--- a/tests/api.js
+++ b/tests/api.js
@@ -8,7 +8,8 @@ const {
     BytecodeContractCallEncoder,
     ContractByteArrayEncoder,
     FateApiEncoder,
-    ContractEncoder
+    ContractEncoder,
+    TypeResolver,
 } = require('../src/main')
 
 const CONTRACT = 'Test'
@@ -78,11 +79,14 @@ test('BytecodeContractCallEncoder public API', t => {
 })
 
 test('ContractByteArrayEncoder public API', t => {
-    t.plan(1)
+    t.plan(3)
 
     const encoder = new ContractByteArrayEncoder()
+    const resolver = new TypeResolver()
 
-    t.is(encoder.decode('cb_b4MC7W/bKkpn'), 191919n, 'int')
+    t.is(encoder.decode('cb_b4MC7W/bKkpn'), 191919n)
+    t.is(encoder.decodeWithType('cb_b4MC7W/bKkpn', resolver.resolveType('int')), 191919n)
+    t.is(encoder.encodeWithType(191919n, resolver.resolveType('int')), 'cb_b4MC7W/bKkpn')
 })
 
 test('FateApiEncoder public API', t => {
@@ -104,4 +108,15 @@ test('ContractEncoder public API', t => {
     t.is(contract.vsn, 3n)
     t.is(contract.compilerVersion, '6.1.0')
     t.is(contract.sourceHash, '9002cb1eef1aab8dc7bf983bed79264bcea04a604f096ce8ebe5f9406262a3c8')
+})
+
+test('TypeResolver public API', t => {
+    t.plan(1)
+
+    const resolver = new TypeResolver()
+    const encoder = new ContractByteArrayEncoder()
+    const type = resolver.resolveType({map: ['int', 'bool']})
+    const encoded = encoder.encodeWithType(new Map([[7n, false]]), type)
+
+    t.is(encoded, 'cb_LwEOfzGit9U=')
 })


### PR DESCRIPTION
- split TypeResolver from AciTypeResolver
- add public API TypeResolver to support working with type information
- add encode and decode support with type information to ContractByteArrayEncoder


closes #216 