### PR TITLE
Use byte arrays to store non-unicode fate strings

### DIFF
--- a/src/Serializers/StringSerializer.js
+++ b/src/Serializers/StringSerializer.js
@@ -8,10 +8,14 @@ const byteArraySerializer = new ByteArraySerializer()
 
 class StringSerializer extends BaseSerializer {
     serialize(value) {
-        const encoder = new TextEncoder()
-        const bytes = encoder.encode(value)
+        let bytesOrString = value.valueOf()
 
-        return byteArraySerializer.serialize(bytes)
+        if (typeof bytesOrString === 'string') {
+            const encoder = new TextEncoder()
+            bytesOrString = encoder.encode(bytesOrString)
+        }
+
+        return byteArraySerializer.serialize(bytesOrString)
     }
 
     deserializeStream(data) {
@@ -25,11 +29,10 @@ class StringSerializer extends BaseSerializer {
             throw new FatePrefixError(prefix)
         }
 
-        const decoder = new TextDecoder()
         const [bytes, rest] = byteArraySerializer.deserializeStream(buffer)
 
         return [
-            new FateString(decoder.decode(bytes.valueOf())),
+            new FateString(bytes.valueOf()),
             rest
         ]
     }

--- a/src/types/FateString.js
+++ b/src/types/FateString.js
@@ -1,5 +1,6 @@
 const FateData = require('./FateData')
 const {FateTypeString} = require('../FateTypes')
+const { byteArray2Int } = require('../utils/int2ByteArray')
 
 const toString = (data) => {
     if (data instanceof Uint8Array) {
@@ -10,11 +11,25 @@ const toString = (data) => {
     return data.toString()
 }
 
+const toBytes = (data) => {
+    if (typeof data === 'string') {
+        const encoder = new TextEncoder()
+        return encoder.encode(data)
+    }
+
+    return data
+}
+
+const isUnicodeString = (data) => {
+    const bytes = toBytes(toString(data))
+    return byteArray2Int(data) === byteArray2Int(bytes)
+}
+
 class FateString extends FateData {
     constructor(value) {
         super('string')
 
-        this._value = toString(value)
+        this._value = toBytes(value)
     }
 
     get type() {
@@ -22,10 +37,18 @@ class FateString extends FateData {
     }
 
     toString() {
+        return toString(this._value)
+    }
+
+    toBytes() {
         return this._value
     }
 
     valueOf() {
+        if (isUnicodeString(this._value)) {
+            return this.toString()
+        }
+
         return this._value
     }
 }

--- a/src/utils/int2ByteArray.js
+++ b/src/utils/int2ByteArray.js
@@ -16,6 +16,10 @@ const byteArrayToHexArray = (data) => {
 }
 
 const byteArray2Int = (data) => {
+    if (data.length === 0) {
+        return 0n
+    }
+
     const hex = byteArrayToHexArray(data)
 
     return BigInt('0x' + hex.join(''))

--- a/tests/Serializers/StringSerializer.js
+++ b/tests/Serializers/StringSerializer.js
@@ -5,17 +5,18 @@ const StringSerializer = require('../../src/Serializers/StringSerializer')
 const s = new StringSerializer()
 
 test('Serialize', t => {
-    t.plan(3)
+    t.plan(4)
     t.deepEqual(s.serialize(new FateString("abc")), [13,97,98,99])
     t.deepEqual(s.serialize("abc"), [13,97,98,99])
     t.deepEqual(
         s.serialize("x".repeat(64)),
         [1,0].concat(Array(64).fill(120))
     )
+    t.deepEqual(s.serialize(new FateString(new Uint8Array([253,254,255]))), [13,253,254,255])
 })
 
 test('Deserialize', t => {
-    t.plan(4)
+    t.plan(5)
     t.deepEqual(s.deserialize([13,97,98,99]), new FateString("abc"))
     t.deepEqual(
         s.deserialize([1,0].concat(Array(64).fill(120))),
@@ -23,4 +24,5 @@ test('Deserialize', t => {
     )
     t.deepEqual(s.deserialize([95]), new FateString(""))
     t.throws(() => s.deserialize([0b00001011]), { name: 'FatePrefixError' })
+    t.deepEqual(s.deserialize([13,253,254,255]), new FateString(new Uint8Array([253,254,255])))
 })


### PR DESCRIPTION
extracted from #287

This PR is supported by the Æternity Foundation

> unicode strings implementation - why and how

Firstly, if a contract uses fate strings as bytes, then these bytes can be broken by converting them to strings on js side. To avoid that I propose to keep data as bytes, keeping the same API except that `valueOf` will return bytes instead of a string if the payload is non-unicode.

The issue I had is that some arguments in contract instructions are raw strings, the current implementation breaks them while decoding making impossible to encode them back. For example:
```js
  {
    id: '1f734048',
    name: 'test_bls12_381_fp',
    attributes: [],
    args: { name: 'tuple', valueTypes: [ { name: 'int' } ] },
    returnType: { name: 'bytes', size: 48n },
    instructions: [
      [
        {
          mnemonic: 'PUSH',
          args: [ { mod: 'arg', arg: 0n, type: { name: 'int' } } ]
        },
        {
          mnemonic: 'CALL_T',
          args: [
            {
              mod: 'immediate',
              arg: '��u�', // OR Uint8Array(4) [ 243, 237, 117, 150 ] after this PR
              type: { name: 'string' }
            }
          ]
        }
      ]
    ]
  },
```