### PR TITLE
Allow to decode contract call without function name

### DIFF
--- a/src/AciContractCallEncoder.js
+++ b/src/AciContractCallEncoder.js
@@ -72,7 +72,7 @@ class AciContractCallEncoder {
      * const data = encoder.decodeCall('Test', 'test_string', 'cb_KxHwzCuVGyl3aG9vbHltb2x5zwMSnw==')
      * console.log(`Decoded data: ${data}`)
      * // Outputs:
-     * // Decoded data: ["whoolymoly"]
+     * // Decoded data: { functionId: "f0cc2b95", args: ["whoolymoly"] }
      *
      * @param {string} contract - The contract name as defined in the ACI.
      * @param {string} funName - The function name as defined in the ACI.
@@ -80,7 +80,7 @@ class AciContractCallEncoder {
      * @returns {string} Decoded data
     */
     decodeCall(contract, funName, data) {
-        const {types, _required} = this._typeResolver.getCallTypes(contract, funName)
+        const {types} = this._typeResolver.getCallTypes(contract, funName)
         const calldataType = FateTypeCalldata(funName, types)
 
         return this._byteArrayEncoder.decodeWithType(data, calldataType)

--- a/src/AciContractCallEncoder.js
+++ b/src/AciContractCallEncoder.js
@@ -87,6 +87,29 @@ class AciContractCallEncoder {
     }
 
     /**
+     * Decodes function details by contract calldata
+     *
+     * @example
+     * const data = encoder.decodeFunction('cb_KxHwzCuVGyl3aG9vbHltb2x5zwMSnw==')
+     * console.log(`Decoded data: ${data}`)
+     * // Outputs:
+     * // Decoded data: {
+     * //   contractName: "Test",
+     * //   functionName: "test_string",
+     * //   functionId: "f0cc2b95",
+     * // }
+     *
+     * @param {string} data - Encoded calldata in canonical format.
+     * @returns {object} Decoded function details
+    */
+    decodeFunction(data) {
+        const {functionId} = this._byteArrayEncoder.decodeWithType(data, FateTypeCalldata())
+        const {contractName, functionName} = this._typeResolver.getFunction(functionId)
+
+        return {contractName, functionName, functionId}
+    }
+
+    /**
      * Decodes successful (resultType = ok) contract call return data
      *
      * @example

--- a/src/AciTypeResolver.js
+++ b/src/AciTypeResolver.js
@@ -1,6 +1,8 @@
 import TypeResolver from './TypeResolver.js'
 import TypeResolveError from './Errors/TypeResolveError.js'
 import {FateTypeEvent} from './FateTypes.js'
+import {symbolIdentifier} from './utils/hash.js'
+import {byteArray2Hex} from './utils/int2ByteArray.js'
 
 const isObject = (value) => {
     return value && typeof value === 'object' && value.constructor === Object
@@ -139,6 +141,18 @@ class AciTypeResolver extends TypeResolver {
         const typeDef = vars.hasOwnProperty(def.typedef) ? vars[def.typedef] : def.typedef
 
         return [typeDef, vars]
+    }
+
+    getFunction(functionId) {
+        const { contract } = this.aci.at(-1)
+        const functionName = contract.functions
+            .map(e => e.name)
+            .find((name) => byteArray2Hex(symbolIdentifier(name)) === functionId)
+        if (functionName == null) {
+            throw new TypeResolveError(`Unknown function id ${functionId}`)
+        }
+
+        return { contractName: contract.name, functionName }
     }
 }
 

--- a/src/api/AciContractCallEncoder.js
+++ b/src/api/AciContractCallEncoder.js
@@ -51,6 +51,26 @@ class AciContractCallEncoder {
     }
 
     /**
+     * * Decodes function details by contract calldata
+     *
+     * @example
+     * const data = encoder.decodeFunction('cb_KxHwzCuVGyl3aG9vbHltb2x5zwMSnw==')
+     * console.log(`Decoded data: ${data}`)
+     * // Outputs:
+     * // Decoded data: {
+     * //   contractName: "Test",
+     * //   functionName: "test_string",
+     * //   functionId: "f0cc2b95",
+     * // }
+     *
+     * @param {string} data - Encoded calldata in canonical format.
+     * @returns {object} Decoded function details
+    */
+    decodeFunction(data) {
+        return this._internalEncoder.decodeFunction(data)
+    }
+
+    /**
      * Decodes successful (resultType = ok) contract call return data
      *
      * @example

--- a/src/api/AciContractCallEncoder.js
+++ b/src/api/AciContractCallEncoder.js
@@ -39,7 +39,7 @@ class AciContractCallEncoder {
      * const data = encoder.decodeCall('Test', 'test_string', 'cb_KxHwzCuVGyl3aG9vbHltb2x5zwMSnw==')
      * console.log(`Decoded data: ${data}`)
      * // Outputs:
-     * // Decoded data: ["whoolymoly"]
+     * // Decoded data: { functionId: "f0cc2b95", args: ["whoolymoly"] }
      *
      * @param {string} contract - The contract name as defined in the ACI.
      * @param {string} funName - The function name as defined in the ACI.

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -31,6 +31,12 @@ export class AciContractCallEncoder {
     args: any[];
   };
 
+  decodeFunction(data: `cb_${string}`): {
+    contractName: string;
+    functionName: string;
+    functionId: string;
+  };
+
   decodeResult(
     contract: string,
     funName: string,

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -26,7 +26,10 @@ export class AciContractCallEncoder {
 
   encodeCall(contract: string, funName: string, args: any[]): `cb_${string}`;
 
-  decodeCall(contract: string, funName: string, data: `cb_${string}`): any;
+  decodeCall(contract: string, funName: string, data: `cb_${string}`): {
+    functionId: string;
+    args: any[];
+  };
 
   decodeResult(
     contract: string,

--- a/tests/AciContractCallEncoder.js
+++ b/tests/AciContractCallEncoder.js
@@ -82,6 +82,22 @@ test('Decode calldata', t => {
     )
 })
 
+test('Decode calldata without function name', t => {
+    t.plan(1)
+    const decoded = encoder.decodeFunction(
+        'cb_KxGu5Sw8G6+CAAQBSzsrAgQGCK+EAAABAAIbFCg7KwIEBgj8xaf6',
+    )
+
+    t.deepEqual(
+        decoded,
+        {
+            contractName: CONTRACT,
+            functionName: 'test_template_maze',
+            functionId: 'aee52c3c',
+        }
+    )
+})
+
 test('Decode implicit init (void) result', t => {
     t.plan(1)
     t.is(


### PR DESCRIPTION
I feel missed the ability to decode contract call without knowing the function name using ACI. The requirement to provide function name looks unnecessary since the calldata already prefixed with the hash of that name.

To avoid ambiguity I propose to limit decoding only to the main contract (the last in ACI).

At last, I don't see a way for good naming without breaking changes.

This PR is supported by the Æternity Foundation