### PR TITLE
Emulate CJS behavior in MJS by adding a default export

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -15,3 +15,16 @@ export {
     ContractEncoder,
     TypeResolver,
 }
+
+/**
+ * @deprecated use named exports instead
+ */
+export default {
+    Encoder,
+    AciContractCallEncoder,
+    BytecodeContractCallEncoder,
+    ContractByteArrayEncoder,
+    FateApiEncoder,
+    ContractEncoder,
+    TypeResolver,
+}


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

This PR reverts a breaking change unintentionally made in 1.9.0

solves https://github.com/aeternity/aepp-cli-js/issues/262

@aeternity/aepp-cli imports @aeternity/aepp-calldata as
```js
import _aeternityAeppCalldata from '@aeternity/aepp-calldata';
```
in an MJS file. Before 1.9.0 _aeternityAeppCalldata was an object exported by common JS. Using 1.9.0 calldata, the node picks the MJS version of calldata which doesn't have a default export, so it fails with

> The requested module '@aeternity/aepp-calldata' does not provide an export named 'default'

I propose adding a default export to fix existing packages. I've tested this using `npm link` and it works.