### PR TITLE
Fix importing in CJS nodejs by adding conditional export

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "types": "src/main.d.ts",
   "exports": {
     "types": "./src/main.d.ts",
-    "import": "./src/main.js"
+    "import": "./src/main.js",
+    "require": "./cjs/main.cjs"
   },
   "files": [
     "cjs/*",


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

I discovered that the recent calldata package can't be imported into a CJS file in nodejs.
```js
// test.cjs
const { Encoder } = require('@aeternity/aepp-calldata');

console.log('Encoder', Encoder);
```
fails with

> Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /.../test-aeproject-2/node_modules/@aeternity/aepp-calldata/package.json

using nodejs@20.18 and @aeternity/aepp-calldata@1.9.0. Looks like `"type": "module",` in package.json we added recently enabled the usage of `exports` instead `main` in this case 👉 👈 